### PR TITLE
Metric fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,6 @@ struct Conn<C, E> {
 
 impl<C, E> Conn<C, E> {
     fn close(&self, internals: &mut MutexGuard<'_, PoolInternals<C, E>>) {
-        decrement_gauge!(ACTIVE_CONNECTIONS, 1.0);
         internals.num_open -= 1;
     }
 
@@ -563,6 +562,7 @@ async fn recycle_conn<M: Manager>(
     shared: &Arc<SharedPool<M>>,
     conn: Conn<M::Connection, M::Error>,
 ) {
+    decrement_gauge!(ACTIVE_CONNECTIONS, 1.0);
     let internals = shared.internals.lock().await;
     put_conn(shared, internals, conn).await;
 }

--- a/src/metrics_utils.rs
+++ b/src/metrics_utils.rs
@@ -1,9 +1,9 @@
 use metrics::{describe_gauge, describe_histogram};
 
-pub const ACTIVE_CONNECTIONS: &str = "pool.active_connections";
-pub const IDLE_CONNECTIONS: &str = "pool.idle_connections";
-pub const WAIT_COUNT: &str = "pool.wait_count";
-pub const WAIT_DURATION: &str = "pool.wait_duration";
+pub const ACTIVE_CONNECTIONS: &str = "pool_active_connections";
+pub const IDLE_CONNECTIONS: &str = "pool_idle_connections";
+pub const WAIT_COUNT: &str = "pool_wait_count";
+pub const WAIT_DURATION: &str = "pool_wait_duration";
 
 pub fn describe_metrics() {
     describe_gauge!(


### PR DESCRIPTION
Change all "." in metric names to "_". Prometheus doesn't support
that. Fix the decrement of an active connection to the drop of the
connection.