### PR TITLE
Rename metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ futures-timer = "3.0.2"
 log = "0.4"
 thiserror = "1.0"
 metrics = "0.18"
+tracing = { version = "0.1", features = ["attributes"] }
+tracing-subscriber = "0.3.11"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/src/metrics_utils.rs
+++ b/src/metrics_utils.rs
@@ -1,28 +1,40 @@
-use metrics::{describe_gauge, describe_histogram};
+use metrics::{describe_counter, describe_gauge, describe_histogram};
 
-pub const ACTIVE_CONNECTIONS: &str = "pool_active_connections";
-pub const IDLE_CONNECTIONS: &str = "pool_idle_connections";
-pub const WAIT_COUNT: &str = "pool_wait_count";
-pub const WAIT_DURATION: &str = "pool_wait_duration_ms";
+pub const OPENED_TOTAL: &str = "prisma_pool_connections_opened_total";
+pub const CLOSED_TOTAL: &str = "prisma_pool_connections_closed_total";
+pub const OPEN_CONNECTIONS: &str = "prisma_pool_connections_open";
+
+pub const ACTIVE_CONNECTIONS: &str = "prisma_pool_connections_busy";
+pub const IDLE_CONNECTIONS: &str = "prisma_pool_connections_idle";
+pub const WAIT_COUNT: &str = "prisma_client_queries_wait";
+pub const WAIT_DURATION: &str = "prisma_client_queries_wait_histogram_ms";
 
 pub fn describe_metrics() {
+    describe_counter!(OPENED_TOTAL, "Total number of Pool Connections opened");
+    describe_counter!(CLOSED_TOTAL, "Total number of Pool Connections closed");
+
+    describe_gauge!(
+        OPEN_CONNECTIONS,
+        "Number of currently open Pool Connections"
+    );
+
     describe_gauge!(
         ACTIVE_CONNECTIONS,
-        "The number of active connections in use."
+        "Number of currently busy Pool Connections (executing a datasource query)"
     );
 
     describe_gauge!(
         IDLE_CONNECTIONS,
-        "The number of connections that are not being used"
+        "Number of currently unused Pool Connections (waiting for the next datasource query to run)"
     );
 
     describe_gauge!(
         WAIT_COUNT,
-        "The number of workers waiting for a connection."
+        "Number of Prisma Client queries currently waiting for a connection"
     );
 
     describe_histogram!(
         WAIT_DURATION,
-        "The wait time for a worker to get a connection."
+        "Histogram of the wait time of all Prisma Client Queries in ms"
     );
 }

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -1,4 +1,6 @@
 use std::future::Future;
+use tracing::instrument::WithSubscriber;
+use tracing::Dispatch;
 
 /// Spawns a new asynchronous task.
 pub fn spawn<T>(task: T)
@@ -10,7 +12,7 @@ where
         feature = "tokio",
         not(any(feature = "async-std", feature = "actix-rt"))
     ))]
-    tokio::spawn(task);
+    spawn_tokio(task);
 
     #[cfg(all(feature = "async-std", not(feature = "actix-rt")))]
     async_std::task::spawn(task);
@@ -19,4 +21,25 @@ where
     actix_rt::spawn(async {
         task.await;
     });
+}
+
+#[cfg(all(
+    feature = "tokio",
+    not(any(feature = "async-std", feature = "actix-rt"))
+))]
+pub fn spawn_tokio<T>(task: T)
+where
+    T: Future + Send + 'static,
+    T::Output: Send + 'static,
+{
+    let dispatcher = get_current_dispatcher();
+    tokio::spawn(task.with_subscriber(dispatcher.clone()));
+}
+
+#[cfg(all(
+    feature = "tokio",
+    not(any(feature = "async-std", feature = "actix-rt"))
+))]
+pub fn get_current_dispatcher() -> Dispatch {
+    tracing::dispatcher::get_default(|current| current.clone())
 }


### PR DESCRIPTION
Renames the metrics to follow the Prisma naming convention.
Add the current dispatcher to the tokio::spawn call.
If a dispatcher/subscriber is added via `with_subscriber` in a higher
level, the dispatcher will not automatically be added to the spawn
event. Using the `with_subscriber` will fix that.