### PR TITLE
fix: remove the locking around pool state

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,7 @@ pub(crate) struct ShareConfig {
     pub health_check_interval: Option<Duration>,
 }
 
+#[derive(Clone)]
 pub(crate) struct InternalConfig {
     pub max_open: u64,
     pub max_idle: u64,

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -33,7 +33,7 @@ where
     T::Output: Send + 'static,
 {
     let dispatcher = get_current_dispatcher();
-    tokio::spawn(task.with_subscriber(dispatcher.clone()));
+    tokio::spawn(task.with_subscriber(dispatcher));
 }
 
 #[cfg(all(


### PR DESCRIPTION
Mobc keeps a set of pool state info. It would often require a lock before updating them. This PR changes the pool state info to use atomics in most places and reduces the amount of locking.

This improves the performance around getting a new or existing connection from the pool.
Using a very simple test like this:

```typescript
const rawQuery = async (i) => {
  let start = process.hrtime.bigint()
  await prisma.$queryRaw`SELECT 5`
  const end = process.hrtime.bigint()
  let diff = end - start
  console.log(`${i}  ${diff / BigInt(1000000)} ms`)
}

function sleep(ms) {
  return new Promise((resolve) => setTimeout(resolve, ms))
}

async function run() {
  await tracer.startActiveSpan('main', async (span) => {
    try {
      const promises: Promise<any>[] = []
      const spans: any[] = []
      for (let i = 0; i < NUM_WRITES; i++) {
        promises.push(
          tracer.startActiveSpan(`create ${i}`, (qspan) => {
            spans[i] = qspan
            return rawQuery(i).then(() => {
              spans[i].end()
            })
          }),
        )
      }
      // @ts-ignore
      await Promise.allSettled(promises)
    } finally {
      span.end()
    }
  })
}

async function main() {

  await prisma.$connect()


  for (let i = 0; i < 5; i++) {
    console.log('run ', i)
    await run()
  }

  await prisma.$disconnect()
}

main().then(() => {
  provider.shutdown()
  console.log('complete')
})
```

The results before this fix:
```
run  0
9  27 ms
4  37 ms
1  46 ms
7  48 ms
5  57 ms
6  57 ms
0  60 ms
2  69 ms
8  69 ms
3  71 ms
run  1
0  3 ms
2  4 ms
3  4 ms
4  4 ms
1  4 ms
7  11 ms
8  11 ms
9  11 ms
6  11 ms
5  12 ms
run  2
7  2 ms
5  2 ms
1  3 ms
2  3 ms
8  3 ms
0  3 ms
4  12 ms
9  12 ms
3  12 ms
6  13 ms
run  3
2  3 ms
3  3 ms
4  3 ms
5  3 ms
0  3 ms
1  3 ms
6  3 ms
8  13 ms
9  13 ms
7  15 ms
run  4
1  2 ms
6  2 ms
5  3 ms
7  3 ms
8  3 ms
0  3 ms
2  3 ms
3  3 ms
4  11 ms
9  13 ms
```

And then after:

```
PRISMA
run  0
1  24 ms
9  36 ms
5  37 ms
7  44 ms
2  46 ms
6  48 ms
3  49 ms
0  50 ms
4  51 ms
8  51 ms
run  1
0  4 ms
1  4 ms
2  4 ms
3  4 ms
4  4 ms
5  4 ms
6  4 ms
7  4 ms
8  4 ms
9  4 ms
run  2
0  3 ms
1  3 ms
2  3 ms
3  3 ms
4  3 ms
5  3 ms
6  3 ms
7  4 ms
8  4 ms
9  4 ms
run  3
0  3 ms
1  3 ms
2  3 ms
3  3 ms
4  3 ms
5  3 ms
6  3 ms
7  3 ms
8  3 ms
9  3 ms
run  4
0  2 ms
1  2 ms
2  2 ms
3  2 ms
4  2 ms
5  2 ms
6  2 ms
7  2 ms
8  2 ms
9  2 ms
```
